### PR TITLE
Add novels directory if missing

### DIFF
--- a/logic/fileLogic.js
+++ b/logic/fileLogic.js
@@ -38,8 +38,19 @@ exports.UpdateMetadata = metadata => {
 }
 
 exports.GetAllNovels = async () => {
-  const folders = await fs.readdir(rootFolder, { withFileTypes: true })
   const novels = []
+
+  let folders = []
+  try {
+    folders = await fs.readdir(rootFolder, { withFileTypes: true })
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.log(`Could not find ${rootFolder}, creating directory.`)
+      await fs.mkdir(rootFolder)
+    } else {
+      console.log(error)
+    }
+  }
 
   for (const folder of folders) {
     if (!folder.isDirectory()) {


### PR DESCRIPTION
On first startup, the server will encounter an error as it will try to read the "novels" directory, but will not be able to find it. This change resolves this issue by creating the directory if it does not exist. In this case, the `GetAllNovels` function will return an empty array - if the directory did not exist, we can assume the user did not have any novels previously downloaded.